### PR TITLE
HOME-104 - Make config path to change WIFI ssid and password

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -1,32 +1,41 @@
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <EEPROM.h>
+
+typedef struct WiFiCredentials {
+    char *ssid;
+    char *pass;
+} WiFiCredentials;
  
 ESP8266WebServer server(80);
 const char* ssid = "ESPWebServer";
 const char* password = "12345678";
+int retries = 10;
 
 String readString;
  
 void setup() {
+  EEPROM.begin(512);
   Serial.begin(9600);
-  //WiFi.begin("", "");
+  
+  WiFi.begin("", "");
  
-  //while (WiFi.status() != WL_CONNECTED) {
-  //  delay(500);
-  //}
-  WiFi.mode(WIFI_AP);           //Only Access point
-  WiFi.softAP(ssid, password);  //Start HOTspot removing password will disable security
- 
-  IPAddress myIP = WiFi.softAPIP();
+  /*while (WiFi.status() != WL_CONNECTED || retries > 0) {
+    delay(500);
+    retries--;
+  }*/
+
+  if (WiFi.status() != WL_CONNECTED) {
+    WiFi.mode(WIFI_AP);           //Only Access point
+    WiFi.softAP(ssid, password);  //Start HOTspot removing password will disable security
+    // IPAddress myIP = WiFi.softAPIP(); 
+  }
  
   server.on("/", handleRootPath);   
   server.on("/api", handleApiPath);
   server.on("/config", handleConfigPath);
   
   server.begin();        
-
-  EEPROM.begin(512);
 }
  
 void loop() {
@@ -50,38 +59,67 @@ void handleApiPath() {
 void handleConfigPath() {
   const String ssid = server.arg("ssid");
   const String pass = server.arg("pass");
-  const int maxLen = 20;
 
   if (ssid != "" && pass != "") {
-    for(int n = 0; n < maxLen; n++) {
-      char ssidChar = ' ';
-      char passChar = ' ';
+    for(int n = 0; n <= ssid.length() + pass.length() + 1; n++) {
+      char sign = ' ';
   
       if (n < ssid.length()) {
-           ssidChar = ssid[n];
+        sign = ssid[n];
+      } else if (n == ssid.length()) {
+        sign = ':';
+      } else if (n > ssid.length() && n <= ssid.length() + pass.length()) {
+        sign = pass[n - (ssid.length() + 1)];
+      } else if (n == ssid.length() + pass.length() + 1) {
+        sign = ';';
       }
-      if (n < pass.length()) {
-           passChar = pass[n];
-      }    
   
-      EEPROM.write(n, ssidChar); 
-      EEPROM.write(maxLen + n, passChar); 
+      EEPROM.write(n, sign);
     }
-    
     EEPROM.commit();
-    server.send(200, "text/plain", "Persisted");
+    server.send(200, "text/plain", "Persisted [" + ssid + "|" + pass + "]");
   } else {
-    String ssid = "";
-    String pass = "";
-    
-    for(int n = 0; n < maxLen; n++) {
-      ssid += char(EEPROM.read(n)); 
-      pass += char(EEPROM.read(maxLen + n)); 
-    }
-
-    ssid.trim();
-    pass.trim();
-    
-    server.send(200, "text/plain", "[" + ssid + "|" + pass + "]");
+    char* ssid;
+    char* pass;
+    getWiFiCredentials(&ssid, &pass); 
+    server.send(200, "text/plain", "[" + String(ssid) + "|" + String(pass) + "]");
   }
 }
+
+void getWiFiCredentials(char** ssid, char** pass) {
+  char currChar;
+  char charBuff[100];
+  unsigned int totalLen = 0;
+  unsigned int ssidLen = 0;
+  unsigned int passLen = 0;
+  unsigned int separatorIndex = 0;
+  
+  while(totalLen < 100) {
+    currChar = char(EEPROM.read(totalLen));
+
+    if (currChar == ';') {
+      break;
+    }
+    
+    charBuff[totalLen] = currChar;
+
+    if (currChar == ':') {
+      separatorIndex = totalLen;
+    }
+    
+    totalLen++;
+  }
+
+  *ssid = (char*)malloc(sizeof(char) * (separatorIndex + 1));       // abc:123 (4)
+  *pass = (char*)malloc(sizeof(char) * (totalLen - separatorIndex + 1));// 0123456 tL = 7 (4
+
+  for(int i = 0; i < separatorIndex; i++) {
+    (*ssid)[i] = charBuff[i];
+  }
+  (*ssid)[separatorIndex] = '\0';
+  for(int i = separatorIndex + 1; i <= totalLen + 1; i++) {
+    (*pass)[i - (separatorIndex + 1)] = charBuff[i];
+  }
+  (*pass)[totalLen + 1] = '\0';
+}
+

--- a/main/main.ino
+++ b/main/main.ino
@@ -47,7 +47,7 @@ void loop() {
 }
 
 void handleRootPath() {
-  server.send(200, "text/plain", "Hardware: agent-type-1");
+  server.send(200, "text/plain", "Smart home agent");
 }
 
 void handleApiPath() {

--- a/main/main.ino
+++ b/main/main.ino
@@ -3,9 +3,9 @@
 #include <EEPROM.h>
  
 ESP8266WebServer server(80);
-const char* hsSsid = "ESPWebServer";
+const char* hsSsid = "SmaHotSpot";
 const char* hsPass = "12345678";
-int retries = 200;
+unsigned int retries = 200;
 
 String readString;
  

--- a/main/main.ino
+++ b/main/main.ino
@@ -1,24 +1,32 @@
 #include <ESP8266WiFi.h>
-#include <ESP8266WebServer.h> 
+#include <ESP8266WebServer.h>
+#include <EEPROM.h>
  
 ESP8266WebServer server(80);
+const char* ssid = "ESPWebServer";
+const char* password = "12345678";
 
 String readString;
-
-const String agentType = "SHA-0.2.0";
  
 void setup() {
   Serial.begin(9600);
-  WiFi.begin("", "");
+  //WiFi.begin("", "");
  
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
-  }
+  //while (WiFi.status() != WL_CONNECTED) {
+  //  delay(500);
+  //}
+  WiFi.mode(WIFI_AP);           //Only Access point
+  WiFi.softAP(ssid, password);  //Start HOTspot removing password will disable security
+ 
+  IPAddress myIP = WiFi.softAPIP();
  
   server.on("/", handleRootPath);   
   server.on("/api", handleApiPath);
+  server.on("/config", handleConfigPath);
   
-  server.begin();                   
+  server.begin();        
+
+  EEPROM.begin(512);
 }
  
 void loop() {
@@ -31,7 +39,7 @@ void loop() {
 }
 
 void handleRootPath() {
-  server.send(200, "text/plain", "Agent type: " + agentType  + " IP address: " + WiFi.localIP());
+  server.send(200, "text/plain", "Hardware: agent-type-1");
 }
 
 void handleApiPath() {
@@ -39,3 +47,41 @@ void handleApiPath() {
   readString = "";
 }
 
+void handleConfigPath() {
+  const String ssid = server.arg("ssid");
+  const String pass = server.arg("pass");
+  const int maxLen = 20;
+
+  if (ssid != "" && pass != "") {
+    for(int n = 0; n < maxLen; n++) {
+      char ssidChar = ' ';
+      char passChar = ' ';
+  
+      if (n < ssid.length()) {
+           ssidChar = ssid[n];
+      }
+      if (n < pass.length()) {
+           passChar = pass[n];
+      }    
+  
+      EEPROM.write(n, ssidChar); 
+      EEPROM.write(maxLen + n, passChar); 
+    }
+    
+    EEPROM.commit();
+    server.send(200, "text/plain", "Persisted");
+  } else {
+    String ssid = "";
+    String pass = "";
+    
+    for(int n = 0; n < maxLen; n++) {
+      ssid += char(EEPROM.read(n)); 
+      pass += char(EEPROM.read(maxLen + n)); 
+    }
+
+    ssid.trim();
+    pass.trim();
+    
+    server.send(200, "text/plain", "[" + ssid + "|" + pass + "]");
+  }
+}

--- a/main/main.ino
+++ b/main/main.ino
@@ -1,34 +1,33 @@
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <EEPROM.h>
-
-typedef struct WiFiCredentials {
-    char *ssid;
-    char *pass;
-} WiFiCredentials;
  
 ESP8266WebServer server(80);
-const char* ssid = "ESPWebServer";
-const char* password = "12345678";
-int retries = 10;
+const char* hsSsid = "ESPWebServer";
+const char* hsPass = "12345678";
+int retries = 200;
 
 String readString;
  
 void setup() {
   EEPROM.begin(512);
   Serial.begin(9600);
+
+  char* ssid;
+  char* pass;
+
+  getWiFiCredentials(&ssid, &pass); 
   
-  WiFi.begin("", "");
+  WiFi.begin(ssid, pass);
  
-  /*while (WiFi.status() != WL_CONNECTED || retries > 0) {
+  while (WiFi.status() != WL_CONNECTED && retries > 0) {
     delay(500);
     retries--;
-  }*/
+  }
 
   if (WiFi.status() != WL_CONNECTED) {
-    WiFi.mode(WIFI_AP);           //Only Access point
-    WiFi.softAP(ssid, password);  //Start HOTspot removing password will disable security
-    // IPAddress myIP = WiFi.softAPIP(); 
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(hsSsid, hsPass);
   }
  
   server.on("/", handleRootPath);   
@@ -110,14 +109,14 @@ void getWiFiCredentials(char** ssid, char** pass) {
     totalLen++;
   }
 
-  *ssid = (char*)malloc(sizeof(char) * (separatorIndex + 1));       // abc:123 (4)
-  *pass = (char*)malloc(sizeof(char) * (totalLen - separatorIndex + 1));// 0123456 tL = 7 (4
+  *ssid = (char*)malloc(sizeof(char) * (separatorIndex + 1));
+  *pass = (char*)malloc(sizeof(char) * (totalLen - separatorIndex + 1));
 
   for(int i = 0; i < separatorIndex; i++) {
     (*ssid)[i] = charBuff[i];
   }
   (*ssid)[separatorIndex] = '\0';
-  for(int i = separatorIndex + 1; i <= totalLen + 1; i++) {
+  for(int i = separatorIndex + 1; i < totalLen; i++) {
     (*pass)[i - (separatorIndex + 1)] = charBuff[i];
   }
   (*pass)[totalLen + 1] = '\0';


### PR DESCRIPTION
**Business justification:** https://trello.com/c/gYc7De7T/104-home-104-make-config-path-to-change-wifi-ssid-and-password

**Description:** For now ESP agents had to have hardcoded ssid and passwords - which caused huge inconvinience for users when password or WiFi name was changed. This PR Introduces functionality that allows to change ssid and passwords in EEPROM memory.