### PR TITLE
HOME-129 - When sending multiple commands hardware hangs

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -53,7 +53,7 @@ void loop() {
   }
 
   if (client && client.connected()) {
-    while (client.available() > 0) {
+    if (client.available() > 0) {
         char c = client.read();
         Serial.write(c);
     }

--- a/main/main.ino
+++ b/main/main.ino
@@ -53,14 +53,14 @@ void loop() {
   }
 
   if (client && client.connected()) {
-    if (client.available() > 0) {
+    while (client.available() > 0) {
         char c = client.read();
         Serial.write(c);
     }
   }
 
   if (Serial.available()) {
-    char c = Serial.read(); 
+    char c = Serial.read();
 
     if (c == '[') {
       prevToken = c;
@@ -74,7 +74,6 @@ void loop() {
     else if (prevToken == ':' && c != ']') {
       if (channel == '1') {
         tcpResponse += c;
-        readString += c;
       }
       else if (channel == '2') {
         readString += c;
@@ -84,7 +83,6 @@ void loop() {
       if (channel == '1') {
         client.print(tcpResponse);
         tcpResponse = "";
-        client.stop();
       }
       channel = '0';
       prevToken = 0;
@@ -126,7 +124,7 @@ void handleConfigPath() {
   } else {
     char* ssid;
     char* pass;
-    getWiFiCredentials(&ssid, &pass); 
+    getWiFiCredentials(&ssid, &pass);
     server.send(200, "text/plain", "[" + String(ssid) + "|" + String(pass) + "]");
   }
 }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/AGwBi4o5/129-home-129-when-sending-multiple-commands-hardware-hangs

**Description:** The reason why hadrware was handing was because when the first command was sent, TCP connection was closed. It should be closed manually by the client, not by the container itself.

Also fix some blank spaces and unnecessary api reader from tcp commands.