### PR TITLE
HOME-134 - Closing connections to clients doesn't work

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -86,7 +86,7 @@ void loop() {
     else if (c == ']') {
       if (channel == '0') {
         if (cmdString == "disconnect") {
-          client.close();
+          client.stop();
         }
         
         cmdString = "";
@@ -102,7 +102,7 @@ void loop() {
 }
 
 void handleRootPath() {
-  server.send(200, "text/plain", "smart-evolution container v0.4.0");
+  server.send(200, "text/plain", "smart-evolution container v0.4.2");
 }
 
 void handleApiPath() {

--- a/main/main.ino
+++ b/main/main.ino
@@ -8,6 +8,7 @@ const char* hsSsid = "SmaHotSpot";
 const char* hsPass = "12345678";
 unsigned int retries = 200;
 
+String cmdString;
 String readString;
 String tcpResponse;
 WiFiClient client;
@@ -72,7 +73,10 @@ void loop() {
       prevToken = c;
     }
     else if (prevToken == ':' && c != ']') {
-      if (channel == '1') {
+      if (channel == '0') {
+        cmdString += c;
+      }
+      else if (channel == '1') {
         tcpResponse += c;
       }
       else if (channel == '2') {
@@ -80,7 +84,14 @@ void loop() {
       }
     }
     else if (c == ']') {
-      if (channel == '1') {
+      if (channel == '0') {
+        if (cmdString == "disconnect") {
+          client.close();
+        }
+        
+        cmdString = "";
+      }
+      else if (channel == '1') {
         client.print(tcpResponse);
         tcpResponse = "";
       }


### PR DESCRIPTION
**Business justification:** HOME-134 - Closing connections to clients doesn't work

**Description:** When user was connected to the device via smarthome-cli and killed the connection from the CLI point of view, hardware was still 'thinking' it was connected. This PR creates a command that can be sent to container in channel 0 to close the connection.

**Related PRs:**
* https://github.com/smart-evolution/smart-home-uc/pull/5
* https://github.com/smart-evolution/smarthome-cli/pull/10
* https://github.com/smart-evolution/smarthome/pull/61
* https://github.com/smart-evolution/smart-home-agent-esp8266/pull/5