### PR TITLE
HOME-166 - Implement various SSID for hardware devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+main/id.h

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ version:
 	git tag $(V)
 	./scripts/changelog.sh
 	git add ./docs/changelogs/CHANGELOG_$(V).md
+    ./scripts/id_generator.sh
 	./scripts/version.sh $(V)
 	git add ./main/version.h
 	git commit --allow-empty -m "Build $(V)"

--- a/main/main.ino
+++ b/main/main.ino
@@ -1,3 +1,4 @@
+#include "id.h"
 #include "version.h"
 #include <EEPROM.h>
 #include <ESP8266WebServer.h>
@@ -5,7 +6,7 @@
 
 ESP8266WebServer server(80);
 WiFiServer tcpServer(81);
-const char *hsSsid = "SmaHotSpot";
+const char *hsSsid = strcat("SH-", HARDWARE_ID);
 const char *hsPass = "12345678";
 unsigned int retries = 200;
 

--- a/scripts/id_generator.sh
+++ b/scripts/id_generator.sh
@@ -1,0 +1,4 @@
+V=$(cat /dev/urandom | env LC_CTYPE=C tr -dc '0-9' | fold -w 8 | head -n 1)
+touch ./main/id.h
+echo "#define HARDWARE_ID \"$V\"" > ./main/id.h
+


### PR DESCRIPTION
**Business justification:** https://trello.com/c/VUxEVOti/166-home-implement-various-ssid-for-hardware-devices

**Description:** A bug was introduced when the same SSID for ESP agents was added. Devices weren't been able to distinguish ESP containers and treated then as a single WiFi device. This PR adds uniquer hardware ID and uses it as a postfix for SSID name.